### PR TITLE
Allowed for duplicate breadcrumb titles/Added uri check

### DIFF
--- a/src/Mj/Breadcrumb/Breadcrumb.php
+++ b/src/Mj/Breadcrumb/Breadcrumb.php
@@ -45,16 +45,16 @@ class Breadcrumb
 
         $output .= '<div itemscope itemtype="http://schema.org/WebPage">';
         $output .= '<ol class="breadcrumb" itemprop="breadcrumb">';
-        foreach ($this->breadcrumbs as $key => $value) {
+        foreach ($this->breadcrumbs as $breadcrumb) {
 
-            $title = $ucfirst===true ? ucfirst($key) : $key;
+            $title = $ucfirst===true ? ucfirst($breadcrumb['title']) : $breadcrumb['title'];
             
             if ($count === $totalBreadcrumbs) {
                 $output .= '<li class="active">' . $title . '</li>';
-            } elseif (empty($value)) {
+            } elseif (empty($breadcrumb['uri'])) {
                 $output .= '<li>' . $title . '</li>';
             } else {
-                $output .= '<li><a href="' . $value . '">' . $title . '</a>';
+                $output .= '<li><a href="' . $breadcrumb['uri'] . '">' . $title . '</a>';
             }
 
             if ($count < $totalBreadcrumbs) {
@@ -72,7 +72,10 @@ class Breadcrumb
     
     public function addBreadcrumb($title, $uri = null)
     {
-        $this->breadcrumbs[$title] = $uri;
+        $this->breadcrumbs[] = array(
+            'title' => $title,
+            'uri' => $uri
+        );
 
         return $this;
     }

--- a/src/Mj/Breadcrumb/Breadcrumb.php
+++ b/src/Mj/Breadcrumb/Breadcrumb.php
@@ -41,17 +41,23 @@ class Breadcrumb
         $output = '';
         $count  = 1;
 
+        $totalBreadcrumbs = count($this->breadcrumbs);
+
         $output .= '<div itemscope itemtype="http://schema.org/WebPage">';
         $output .= '<ol class="breadcrumb" itemprop="breadcrumb">';
         foreach ($this->breadcrumbs as $key => $value) {
+
+            $title = $ucfirst===true ? ucfirst($key) : $key;
             
-            if ($count != count($this->breadcrumbs)) {
-                $output .= '<li><a href="' . $value . '">' . ($ucfirst? ucfirst($key) : $key) . '</a>';
+            if ($count === $totalBreadcrumbs) {
+                $output .= '<li class="active">' . $title . '</li>';
+            } elseif (empty($value)) {
+                $output .= '<li>' . $title . '</li>';
             } else {
-                $output .= '<li class="active">' . ($ucfirst? ucfirst($key) : $key) . '</li>';
+                $output .= '<li><a href="' . $value . '">' . $title . '</a>';
             }
 
-            if ($count != count($this->breadcrumbs)) {
+            if ($count < $totalBreadcrumbs) {
                 $output .= ' ' . $this->separator . '</li>';
             }
 


### PR DESCRIPTION
A couple of fixes. I've updated the code to prevent breadcrumbs being overwritten if there is a duplicate breadcrumb title. Ideally this wouldn't happen, but when creating a breadcrumb from user supplied content there can be cases where a breadcrumb occurs multiple times (using the title as the array index prohibited this).

I've also made sure that a uri has been set when outputting a breadcrumb. This allows the breadcrumbs to be used like a progress bar for a checkout process.
